### PR TITLE
Fix regex_preserve not being passed to nested keys

### DIFF
--- a/animal_case/__init__.py
+++ b/animal_case/__init__.py
@@ -103,11 +103,11 @@ def animalify(*args, **kwargs):
     if type(data) == dict:
         for key, value in _unpack(formatter(data, preserve_regex=preserve_regex)):
             if isinstance(value, dict):
-                formatted[key] = animalify(value, types)
+                formatted[key] = animalify(value, types, preserve_regex)
             elif isinstance(value, list) and len(value) > 0:
                 formatted[key] = []
                 for _, val in enumerate(value):
-                    formatted[key].append(animalify(val, types))
+                    formatted[key].append(animalify(val, types, preserve_regex))
             else:
                 formatted[key] = value
         return formatted
@@ -115,11 +115,11 @@ def animalify(*args, **kwargs):
     else:
         for i, each in enumerate(data):
             if isinstance(each, dict):
-                formatted.append(animalify(each, types))
+                formatted.append(animalify(each, types, preserve_regex))
             elif isinstance(each, list) and len(each) > 0:
                 formatted.append([])
                 for _, val in enumerate(each):
-                    formatted[i].append(animalify(val, types))
+                    formatted[i].append(animalify(val, types, preserve_regex))
             else:
                 formatted.append(each)
         return formatted

--- a/tests/test_animal_case.py
+++ b/tests/test_animal_case.py
@@ -160,9 +160,17 @@ class TestAnimalCase:
         assert converted["nestedKey"]["moreStuff"] == (1, 2, 3)
 
     def test_convert_dict_keys_to_snake_case_preserve_constant_case(self, camel_case_dict):
-        converted = animalify({**camel_case_dict, **{ 'FOURTH_KEY': 4 }}, 'snake', "^[A-Z0-9_]+$")
+        constant_dict = {**camel_case_dict, **{ 'FOURTH_KEY': 4 }}
+        constant_dict['thirdKey'].append({ 'SUB_THIRD_KEY_CONSTANT': 4 })
+        converted = animalify(constant_dict, 'snake', "^[A-Z0-9_]+$")
+
         assert 'FOURTH_KEY' in converted
+        assert 'SUB_THIRD_KEY_CONSTANT' in converted['third_key'][3]
 
     def test_convert_dict_keys_to_camel_case_preserve_constant_case(self, snake_case_dict):
-        converted = animalify({**snake_case_dict, **{ 'FOURTH_KEY': 4 }}, preserve_regex="^[A-Z0-9_]+$")
+        constant_dict = {**snake_case_dict, **{ 'FOURTH_KEY': 4 }}
+        constant_dict['third_key'].append({ 'SUB_THIRD_KEY_CONSTANT': 4 })
+        converted = animalify(constant_dict, preserve_regex="^[A-Z0-9_]+$")
+
         assert 'FOURTH_KEY' in converted
+        assert 'SUB_THIRD_KEY_CONSTANT' in converted['thirdKey'][3]


### PR DESCRIPTION
I'm very stupid and forgot to implement + test recursive cases for nested keys. Sorry about that, we'll need 0.5.1.